### PR TITLE
Fix Event Deletion Bug in Calendar

### DIFF
--- a/src/calendarGoogle.py
+++ b/src/calendarGoogle.py
@@ -174,6 +174,27 @@ def update_event(event_id):
         return jsonify({"error": str(e)}), 500
 
 
+@calendarGoogle.route('/api/calendar/events/<event_id>', methods=['DELETE'])
+def delete_event(event_id):
+    """
+    Delete an existing Google Calendar event.
+
+    Args:
+        event_id (str): The ID of the event to be deleted.
+
+    Returns:
+        Response: JSON response indicating the result of the delete operation.
+    """
+    try:
+        service = get_calendar_service()
+        service.events().delete(
+            calendarId='primary', eventId=event_id).execute()
+
+        return jsonify({"message": "Event deleted successfully."}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
 @calendarGoogle.route('/api/calendar/events/today', methods=['GET'])
 def get_todays_events():
     """


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?**
- Bug fix

**What is the current behavior?**  
The "Delete" button for calendar events does not function as intended. The frontend attempts to send a DELETE request, but no corresponding DELETE endpoint exists in the backend, resulting in no changes to the calendar events.

**What is the new behavior?**  
A new DELETE endpoint is introduced on the server side. The frontend now correctly targets this endpoint when the "Delete" button is clicked. Events are properly removed from Google Calendar and the UI re-renders to reflect the deletion.

**How can we run this change or implement this behavior?**  
- Ensure you are authenticated with Google Calendar.
- Click the "Delete" button on any event in the calendar.
- Verify that the event is removed both visually from the calendar and from the backend data source.
